### PR TITLE
Feature/bump ubuntu to noble 20240827.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,25 +51,7 @@ jobs:
           builder: ${{ steps.setup_buildx.outputs.name }}
           tags: ${{ steps.extract_metadata.outputs.tags }}
           labels: ${{ steps.extract_metadata.outputs.labels }}
+          platforms: linux/riscv64
           annotations: ${{ steps.extract_metadata.outputs.annotations }}
           cache-from: type=gha,scope=ubuntu
           cache-to: type=gha,mode=max,scope=ubuntu
-
-      - name: Extract file from image
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: shrink/actions-docker-extract@v3
-        with:
-          image: ${{ steps.build_image.outputs.imageid }}
-          path: /opt/bundle/builtins.tar.gz
-          destination: out
-
-      - name: Add version to file name
-        if: startsWith(github.ref, 'refs/tags/v')
-        working-directory: out
-        run: mv builtins.tar.gz "builtins-${GITHUB_REF#refs/tags/v}.tar.gz"
-
-      - name: Upload file as release artifact
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: out/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN make -j2 VERSION=0.8.27
 
 ###############################################################################
 
-FROM cryptobughunters/rust:2.2.0 AS rust-builder
+FROM --platform=$BUILDPLATFORM cryptobughunters/rust:2.2.0 AS rust-builder
 WORKDIR /opt/build
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20240801 AS base-builder
+FROM ubuntu:noble-20240827.1 AS base-builder
 WORKDIR /opt/build
 ENV SOURCE_DATE_EPOCH=0
 ARG DEBIAN_FRONTEND=noninteractive
@@ -6,7 +6,7 @@ RUN <<EOF
 set -eu
 apt-get update
 apt install -y --no-install-recommends ca-certificates
-apt update --snapshot=20240801T030400Z
+apt update --snapshot=20240827T030400Z
 EOF
 
 ###############################################################################
@@ -94,7 +94,7 @@ RUN make VERSION=1.0.5
 
 ###############################################################################
 
-FROM ubuntu:noble-20240801 AS bundler
+FROM base-builder AS bundler
 WORKDIR /opt/bundle
 COPY --from=lua-5.4.3-builder --chmod=755 /opt/build/lua-5.4.3 .
 COPY --from=lua-5.4.7-builder --chmod=755 /opt/build/lua-5.4.7 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ set -eu
 apt-get update
 apt install -y --no-install-recommends ca-certificates
 apt update --snapshot=20240827T030400Z
+apt install -y --no-install-recommends curl
 EOF
 
 ###############################################################################
@@ -16,8 +17,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y --no-install-recommends \
     build-essential \
     gcc-riscv64-linux-gnu \
-    libc-dev-riscv64-cross \
-    wget
+    libc-dev-riscv64-cross
 
 ###############################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20240827.1 AS base-builder
+FROM --platform=$BUILDPLATFORM ubuntu:noble-20240827.1 AS base-builder
 WORKDIR /opt/build
 ENV SOURCE_DATE_EPOCH=0
 ARG DEBIAN_FRONTEND=noninteractive
@@ -94,7 +94,7 @@ RUN make VERSION=1.0.5
 
 ###############################################################################
 
-FROM base-builder AS bundler
+FROM --platform=$TARGETPLATFORM scratch
 WORKDIR /opt/bundle
 COPY --from=lua-5.4.3-builder --chmod=755 /opt/build/lua-5.4.3 .
 COPY --from=lua-5.4.7-builder --chmod=755 /opt/build/lua-5.4.7 .
@@ -104,8 +104,3 @@ COPY --from=sqlite-3.43.2-builder --chmod=755 /opt/build/sqlite-3.43.2 .
 COPY --from=solc-0.8.27-builder --chmod=755 /opt/build/solc-0.8.27 .
 COPY --from=forge-2cdbfac-builder --chmod=755 /opt/build/forge-2cdbfac .
 COPY --from=reth-1.0.5-builder --chmod=755 /opt/build/reth-1.0.5 .
-RUN tar --sort=name \
-    --mtime=@0 \
-    --owner=0 --group=0 --numeric-owner \
-    --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-    -czf builtins.tar.gz *

--- a/busybox/Makefile
+++ b/busybox/Makefile
@@ -25,4 +25,4 @@ $(SRC_DIR): $(SRC_TAR)
 	tar xf $< -C $(DEST_DIR)
 
 $(SRC_TAR):
-	wget https://busybox.net/downloads/$(SRC_TAR)
+	curl -fsSL -O https://busybox.net/downloads/$(SRC_TAR)

--- a/lua/Makefile
+++ b/lua/Makefile
@@ -21,4 +21,4 @@ $(SRC_DIR): $(SRC_TAR)
 	tar xf $< -C $(DEST_DIR)
 
 $(SRC_TAR):
-	wget https://www.lua.org/ftp/$@
+	curl -fsSL -O https://www.lua.org/ftp/$@

--- a/solc/Makefile
+++ b/solc/Makefile
@@ -42,7 +42,7 @@ $(SOLC_SRC_DIR): $(SOLC_SRC_TAR)
 	tar xf $<
 
 $(SOLC_SRC_TAR):
-	wget -O $@ https://github.com/ethereum/solidity/releases/download/v$(VERSION)/$@
+	curl -fsSL -O https://github.com/ethereum/solidity/releases/download/v$(VERSION)/$@
 
 $(BOOST_INSTALLATION_DIR): $(BOOST_SRC_DIR) $(BOOST_USER_CONFIG_FILE)
 	mkdir -p $@
@@ -57,4 +57,4 @@ $(BOOST_SRC_DIR): $(BOOST_SRC_TAR)
 	tar xf $<
 
 $(BOOST_SRC_TAR):
-	wget https://boostorg.jfrog.io/artifactory/main/release/$(BOOST_VERSION)/source/$@
+	curl -fsSL -O https://boostorg.jfrog.io/artifactory/main/release/$(BOOST_VERSION)/source/$@

--- a/sqlite/Makefile
+++ b/sqlite/Makefile
@@ -14,7 +14,7 @@ sqlite-$(VERSION): $(SRC_DIR)/sqlite3.c
 	$(CC) -o $@ $(HARDEN_CFLAGS) $(SQLITE_CFLAGS) $(SRC_DIR)/shell.c $(SRC_DIR)/sqlite3.c $(HARDEN_LDFLAGS) $(SQLITE_LDFLAGS)
 	rm -rf $(SRC_TAR) $(SRC_DIR)
 
-$(SRC_DIR)/sqlite3.c: $(SRC_DIR) 
+$(SRC_DIR)/sqlite3.c: $(SRC_DIR)
 	cd $< && ./configure --host=$(HOST)
 	make -C $< sqlite3.c
 
@@ -22,4 +22,4 @@ $(SRC_DIR): $(SRC_TAR)
 	tar xf $<
 
 $(SRC_TAR):
-	wget -O $@ https://github.com/sqlite/sqlite/archive/refs/tags/version-$(VERSION).tar.gz
+	curl -fsSL -o $@ https://github.com/sqlite/sqlite/archive/refs/tags/version-$(VERSION).tar.gz


### PR DESCRIPTION
With this, we should release a new 0.5.0 version and adapt bug-buster to get binaries from `ghcr.io/crypto-bug-hunters/builtins:0.5.0` container registry.

I'm not sure if we should still release the binaries at a GH Release page, if it's decided that we should, I can make the adjustments.