### PR TITLE
Feature/chiselled distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN chisel cut \
     --release /chisel-24.04 \
     --root /rootfs \
     --arch=riscv64 \
-    libgcc-s1_libs \
+    libstdc++6_libs \
     libatomic1_libs
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN make VERSION=1.0.5
 
 ###############################################################################
 
-FROM ubuntu:${UBUNTU_TAG} AS chiselled-builder
+FROM base-builder AS chiselled-builder
 WORKDIR /rootfs
 
 # Get chisel binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN make VERSION=5.4.7
 FROM c-builder AS busybox-builder
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y --no-install-recommends bzip2 patch
-COPY busybox/Makefile busybox/config busybox/filter_exit.patch .
+COPY busybox/Makefile busybox/config busybox/filter_exit.patch ./
 
 FROM busybox-builder AS busybox-1.36.1-builder
 RUN make VERSION=1.36.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,24 @@ RUN make VERSION=1.0.5
 
 ###############################################################################
 
-FROM ubuntu:${UBUNTU_TAG}
+FROM ubuntu:${UBUNTU_TAG} AS chiselled-builder
+WORKDIR /rootfs
+
+# Get chisel binary
+ARG CHISEL_VERSION=0.10.0
+ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_riscv64.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+
+ADD "https://github.com/cartesi/chisel-releases.git#ubuntu-24.04-riscv64" /chisel-24.04
+RUN chisel cut \
+    --release /chisel-24.04 \
+    --root /rootfs \
+    --arch=riscv64 \
+    libatomic1_libs
+
+###############################################################################
+
+FROM scratch
 WORKDIR /opt/bundle
 COPY --from=lua-5.4.3-builder --chmod=755 /opt/build/lua-5.4.3-linux-riscv64 .
 COPY --from=lua-5.4.7-builder --chmod=755 /opt/build/lua-5.4.7-linux-riscv64 .
@@ -106,3 +123,4 @@ COPY --from=sqlite-3.43.2-builder --chmod=755 /opt/build/sqlite-3.43.2-linux-ris
 COPY --from=solc-0.8.27-builder --chmod=755 /opt/build/solc-0.8.27-linux-riscv64 .
 COPY --from=forge-2cdbfac-builder --chmod=755 /opt/build/forge-2cdbfac-linux-riscv64 .
 COPY --from=reth-1.0.5-builder --chmod=755 /opt/build/reth-1.0.5-linux-riscv64 .
+COPY --from=chiselled-builder /rootfs /

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ RUN chisel cut \
     --release /chisel-24.04 \
     --root /rootfs \
     --arch=riscv64 \
+    libgcc-s1_libs \
     libatomic1_libs
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,8 @@ ARG CHISEL_VERSION=0.10.0
 ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_riscv64.tar.gz" chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 
-ADD "https://github.com/cartesi/chisel-releases.git#ubuntu-24.04-riscv64" /chisel-24.04
 RUN chisel cut \
-    --release /chisel-24.04 \
+    --release ubuntu-24.04 \
     --root /rootfs \
     --arch=riscv64 \
     libstdc++6_libs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,8 @@ WORKDIR /rootfs
 
 # Get chisel binary
 ARG CHISEL_VERSION=0.10.0
-ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_riscv64.tar.gz" chisel.tar.gz
-RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_riscv64.tar.gz" /tmp/chisel.tar.gz
+RUN tar -xvf /tmp/chisel.tar.gz -C /usr/bin/
 
 RUN chisel cut \
     --release ubuntu-24.04 \


### PR DESCRIPTION
This PR will introduce a distroless container image based on Canonical's `chisel` tool.

COmparing the current ubuntu based to the chiselled one, we have no CVEs, and a reduced final size.

**builtins:0.5.0**

```
> docker images ghcr.io/crypto-bug-hunters/builtins:0.5.0 --format "{{.Repository}}: {{.Size}}"
ghcr.io/crypto-bug-hunters/builtins: 209MB
> grype ghcr.io/crypto-bug-hunters/builtins:0.5.0
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                               ghcr.io/crypto-bug-hunters/builtins:0.5.0
 ✔ Parsed image                                                                                                 sha256:6a9cc6c774cdf62c89656d581686dee88a4795232dcb88ab58e399f1b3e1e779
 ✔ Cataloged contents                                                                                                  7a2734e2eb921648e25993f0c2e747e734daa7b400760cd4b84441f1ccaed847
   ├── ✔ Packages                        [90 packages]
   ├── ✔ File digests                    [2,037 files]
   ├── ✔ File metadata                   [2,037 locations]
   └── ✔ Executables                     [728 executables]
 ✔ Scanned for vulnerabilities     [8 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 3 medium, 3 low, 2 negligible
   └── by status:   1 fixed, 7 not-fixed, 0 ignored
NAME          INSTALLED          FIXED-IN           TYPE  VULNERABILITY   SEVERITY
coreutils     9.4-3ubuntu6                          deb   CVE-2016-2781   Low
gpgv          2.4.4-2ubuntu17                       deb   CVE-2022-3219   Low
libc-bin      2.39-0ubuntu8.3                       deb   CVE-2016-20013  Negligible
libc6         2.39-0ubuntu8.3                       deb   CVE-2016-20013  Negligible
libgcrypt20   1.10.3-2build1                        deb   CVE-2024-2236   Medium
libpcre2-8-0  10.42-4ubuntu2                        deb   CVE-2022-41409  Low
libssl3t64    3.0.13-0ubuntu3.3  3.0.13-0ubuntu3.4  deb   CVE-2024-6119   Medium
libssl3t64    3.0.13-0ubuntu3.3                     deb   CVE-2024-41996  Medium
```

**builtins:pr-15**

```
> docker images ghcr.io/crypto-bug-hunters/builtins:pr-15 --format "{{.Repository}}: {{.Size}}"
ghcr.io/crypto-bug-hunters/builtins: 144MB
> grype ghcr.io/crypto-bug-hunters/builtins:pr-15
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                               ghcr.io/crypto-bug-hunters/builtins:pr-15
 ✔ Parsed image                                                                                                 sha256:2f5cc98b501db3d3a1965a52a0a0627fa0a70661f2b9a2432008a60809f78de2
 ✔ Cataloged contents                                                                                                  fbb2b43af7cc0092511400e18e3974f73ab06597d7eaf02d6145884a00d4eb3a
   ├── ✔ Packages                        [0 packages]
   └── ✔ Executables                     [30 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```

**Running command from the contaienr**

And it's still possible to run the binaries using the container.

```
docker run -ti --rm --platform=linux/riscv64 ghcr.io/crypto-bug-hunters/builtins:pr-15 /opt/bundle/reth-1.0.5-linux-riscv64 --version
reth Version: 1.0.5
Commit SHA: 603e39ab74509e0863fc023461a4c760fb2126d1
Build Timestamp: 1970-01-01T00:00:00.000000000Z
Build Features: jemalloc
Build Profile: release
```