### PR TITLE
fix: add ENTRYPOINT to container image release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN chisel cut \
     --release ubuntu-24.04 \
     --root /rootfs \
     --arch=riscv64 \
+    busybox_bins \
     libstdc++6_libs \
     libatomic1_libs
 
@@ -125,3 +126,5 @@ COPY --from=foundry-2cdbfac-builder --chmod=755 /opt/build/cast-2cdbfac-linux-ri
 COPY --from=foundry-2cdbfac-builder --chmod=755 /opt/build/forge-2cdbfac-linux-riscv64 .
 COPY --from=reth-1.0.5-builder --chmod=755 /opt/build/reth-1.0.5-linux-riscv64 .
 COPY --from=chiselled-builder /rootfs /
+
+ENTRYPOINT ["/usr/bin/busybox", "sh"]


### PR DESCRIPTION
This PR will add an ENTRYPOINT to the builtins container image releqase, so it's possible to copy internal artifacts at CI time.