### PR TITLE
Bump ubuntu release tag to noble-20241009

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UBUNTU_TAG=noble-20240827.1
+ARG UBUNTU_TAG=noble-20241009
 
 FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_TAG} AS base-builder
 WORKDIR /opt/build
@@ -8,7 +8,7 @@ RUN <<EOF
 set -eu
 apt-get update
 apt install -y --no-install-recommends ca-certificates
-apt update --snapshot=20240827T030400Z
+apt update --snapshot=20241010T030400Z
 apt install -y --no-install-recommends curl
 EOF
 


### PR DESCRIPTION
I'm not sure if we need to keep this updated on every ubuntu release tag update, since it would potentially break the reproducibility we achieve with `apt --snapshot`.

But I think we could keep it updated and whenever we know we're gonna generate a new bug-buster snapshot, point the the newest builtins release.

What do you think @guidanoli @claudioantonio ?