### PR TITLE
Bump Ubuntu base image and enhance container build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UBUNTU_TAG=noble-20241015
+ARG UBUNTU_TAG=noble-20241118.1
 
 FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_TAG} AS base-builder
 WORKDIR /opt/build
@@ -8,7 +8,7 @@ RUN <<EOF
 set -eu
 apt-get update
 apt install -y --no-install-recommends ca-certificates
-apt update --snapshot=20241015T030400Z
+apt update --snapshot=20241118T030400Z
 apt install -y --no-install-recommends curl
 EOF
 


### PR DESCRIPTION
Update the Ubuntu base image to noble-20241118.1.