### PR TITLE
Fix Boost link

### DIFF
--- a/solc/Makefile
+++ b/solc/Makefile
@@ -58,4 +58,4 @@ $(BOOST_SRC_DIR): $(BOOST_SRC_TAR)
 	tar xf $<
 
 $(BOOST_SRC_TAR):
-	curl -fsSL -O https://boostorg.jfrog.io/artifactory/main/release/$(BOOST_VERSION)/source/$@
+	curl -fsSL -O https://archives.boost.io/release/$(BOOST_VERSION)/source/$@


### PR DESCRIPTION
[It seems](https://github.com/crypto-bug-hunters/builtins/actions/runs/13034067379/job/36360017142) that the current Boost link at the `solc` build Makefile is out.
I got the new link from https://www.boost.org/users/history/.